### PR TITLE
Add huisnummer and postcode, fix bug with 'vorige' and 'volgende'

### DIFF
--- a/src/Http/SearchMapper.php
+++ b/src/Http/SearchMapper.php
@@ -16,8 +16,8 @@ class SearchMapper
             $response['aantal'],
             $response['totaal'],
             self::extractCompanies($response['resultaten']),
-            (array_key_exists('vorige', $response)) ? $response['vorige'] : null,
             (array_key_exists('volgende', $response)) ? $response['volgende'] : null,
+            (array_key_exists('vorige', $response)) ? $response['vorige'] : null,
         );
     }
 

--- a/src/Http/SearchQuery.php
+++ b/src/Http/SearchQuery.php
@@ -25,6 +25,12 @@ class SearchQuery implements QueryInterface
     private $plaats;
 
     /** @var string */
+    private $postcode;
+
+    /** @var string */
+    private $huisnummer;
+
+    /** @var string */
     private $type;
 
     /** @var int */
@@ -66,6 +72,16 @@ class SearchQuery implements QueryInterface
         $this->plaats = $plaats;
     }
 
+    public function setPostcode(string $postcode)
+    {
+        $this->postcode = $postcode;
+    }
+
+    public function setHuisnummer(string $huisnummer)
+    {
+        $this->huisnummer = $huisnummer;
+    }
+
     public function setType(string $type)
     {
         $this->type = $type;
@@ -95,6 +111,8 @@ class SearchQuery implements QueryInterface
             'handelsnaam' => $this->handelsnaam,
             'straatnaam' => $this->straatnaam,
             'plaats' => $this->plaats,
+            'postcode' => $this->postcode,
+            'huisnummer' => $this->huisnummer,
             'type' => $this->type,
             'inclusiefinactieveregistraties' => $this->inclusiefinactieveregistraties,
             'pagina' => $this->pagina,

--- a/src/Model/Search/ResultaatItem.php
+++ b/src/Model/Search/ResultaatItem.php
@@ -12,6 +12,8 @@ class ResultaatItem
     private $handelsnaam;
     private $straatnaam;
     private $plaats;
+    private $postcode;
+    private $huisnummer;
     private $type;
     private $actief;
     private $vervallenNaam;
@@ -25,6 +27,8 @@ class ResultaatItem
         ?string $handelsnaam,
         ?string $straatnaam,
         ?string $plaats,
+        ?string $postcode,
+        ?string $huisnummer,
         ?string $type,
         ?string $actief,
         ?string $vervallenNaam,
@@ -36,6 +40,8 @@ class ResultaatItem
         $this->handelsnaam = $handelsnaam;
         $this->straatnaam = $straatnaam;
         $this->plaats = $plaats;
+        $this->postcode = $postcode;
+        $this->huisnummer = $huisnummer;
         $this->type = $type;
         $this->actief = $actief;
         $this->vervallenNaam = $vervallenNaam;
@@ -89,5 +95,15 @@ class ResultaatItem
     public function getPlaats(): ?string
     {
         return $this->plaats;
+    }
+
+    public function getPostcode(): ?string
+    {
+        return $this->postcode;
+    }
+
+    public function getHuisnummer(): ?string
+    {
+        return $this->huisnummer;
     }
 }

--- a/src/Model/Search/ResultaatItemFactory.php
+++ b/src/Model/Search/ResultaatItemFactory.php
@@ -18,6 +18,8 @@ class ResultaatItemFactory extends AbstractFactory
             self::pluckString('handelsnaam', $response),
             self::pluckString('straatnaam', $response),
             self::pluckString('plaats', $response),
+            self::pluckString('postcode', $response),
+            self::pluckString('huisnummer', $response),
             self::pluckString('type', $response),
             self::pluckString('actief', $response),
             self::pluckString('vervallenNaam', $response),


### PR DESCRIPTION
Hi,

I've picked up an update from another fork regarding 'huisnummer' and 'postcode' missing in the SearchQuery response. There was a bug in the `fromResponse` method which swapped around 'vorige' and 'volgende'. This has also been fixed :) 