### PR TITLE
Huisnummer in the KVK Handelsregister Zoeken API is an int

### DIFF
--- a/src/Model/Search/ResultaatItem.php
+++ b/src/Model/Search/ResultaatItem.php
@@ -28,7 +28,7 @@ class ResultaatItem
         ?string $straatnaam,
         ?string $plaats,
         ?string $postcode,
-        ?string $huisnummer,
+        ?int $huisnummer,
         ?string $type,
         ?string $actief,
         ?string $vervallenNaam,
@@ -102,7 +102,7 @@ class ResultaatItem
         return $this->postcode;
     }
 
-    public function getHuisnummer(): ?string
+    public function getHuisnummer(): ?int
     {
         return $this->huisnummer;
     }

--- a/src/Model/Search/ResultaatItemFactory.php
+++ b/src/Model/Search/ResultaatItemFactory.php
@@ -19,7 +19,7 @@ class ResultaatItemFactory extends AbstractFactory
             self::pluckString('straatnaam', $response),
             self::pluckString('plaats', $response),
             self::pluckString('postcode', $response),
-            self::pluckString('huisnummer', $response),
+            self::pluckInteger('huisnummer', $response),
             self::pluckString('type', $response),
             self::pluckString('actief', $response),
             self::pluckString('vervallenNaam', $response),


### PR DESCRIPTION
According to the response schema at https://developers.kvk.nl/nl/documentation/zoeken-api#output huisnummer should be an int. This prevents the following exception:

```
Fatal error: Uncaught TypeError: Return value of Appvise\KvkApi\Model\AbstractFactory::pluckString() must be of the type string or null, int returned in /workspaces/kvk-api/src/Model/AbstractFactory.php:13
Stack trace:
#0 /workspaces/kvk-api/src/Model/Search/ResultaatItemFactory.php(22): Appvise\KvkApi\Model\AbstractFactory::pluckString('huisnummer', Array)
#1 /workspaces/kvk-api/src/Http/SearchMapper.php(28): Appvise\KvkApi\Model\Search\ResultaatItemFactory::fromResponse(Array)
#2 /workspaces/kvk-api/src/Http/SearchMapper.php(18): Appvise\KvkApi\Http\SearchMapper::extractCompanies(Array)
#3 /workspaces/kvk-api/src/KvkClient.php(66): Appvise\KvkApi\Http\SearchMapper::fromResponse(Array)
#4 /workspaces/kvk-api/test.php(12): Appvise\KvkApi\KvkClient->search(Object(Appvise\KvkApi\Http\SearchQuery))
#5 {main}
  thrown in /workspaces/kvk-api/src/Model/AbstractFactory.php on line 13
```