### PR TITLE
Feat:  Ondersteuning voor Zoeken V2 endpoint.

### DIFF
--- a/src/Http/SearchMapper.php
+++ b/src/Http/SearchMapper.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Appvise\KvkApi\Http;
 
 use Appvise\KvkApi\Model\Resultaat;
+use Appvise\KvkApi\Model\ResultaatInterface;
 use Appvise\KvkApi\Model\Search\ResultaatItemFactory;
 
 class SearchMapper
@@ -18,6 +19,18 @@ class SearchMapper
             self::extractCompanies($response['resultaten']),
             (array_key_exists('volgende', $response)) ? $response['volgende'] : null,
             (array_key_exists('vorige', $response)) ? $response['vorige'] : null,
+        );
+    }
+
+    public static function fromV2Response(array $response): ResultaatInterface
+    {
+        return new Resultaat(
+            $response['pagina'],
+            $response['resultatenPerPagina'],
+            $response['totaal'],
+            self::extractCompanies($response['resultaten']),
+            $response['volgende'] ?? null,
+            $response['vorige'] ?? null,
         );
     }
 

--- a/src/Http/SearchQuery.php
+++ b/src/Http/SearchQuery.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Appvise\KvkApi\Http;
 
-class SearchQuery implements QueryInterface
+class SearchQuery implements SearchQueryInterface
 {
     /** @var string */
     private $kvkNumber;
@@ -30,6 +30,12 @@ class SearchQuery implements QueryInterface
     /** @var string */
     private $huisnummer;
 
+    /** @var null|string */
+    private $huisletter;
+
+    /** @var null|string */
+    private $postbusnummer;
+
     /** @var string */
     private $type;
 
@@ -41,6 +47,15 @@ class SearchQuery implements QueryInterface
 
     /** @var bool */
     private $inclusiefinactieveregistraties;
+    /**
+     * @var bool
+     */
+    private $isEndpointVersion1;
+
+    public function __construct(bool $isEndpointVersion1 = true)
+    {
+        $this->isEndpointVersion1 = $isEndpointVersion1;
+    }
 
     public function setKvkNumber(string $kvkNumber)
     {
@@ -82,6 +97,16 @@ class SearchQuery implements QueryInterface
         $this->huisnummer = $huisnummer;
     }
 
+    public function setHuisletter(?string $huisletter): void
+    {
+        $this->huisletter = $huisletter;
+    }
+
+    public function setPostbusnummer(string $postbusnummer): void
+    {
+        $this->postbusnummer = $postbusnummer;
+    }
+
     public function setType(string $type)
     {
         $this->type = $type;
@@ -102,9 +127,16 @@ class SearchQuery implements QueryInterface
         $this->aantal = $aantal;
     }
 
+    public function setIsEndpointVersion1(bool $isEndpointVersion1): self
+    {
+        $this->isEndpointVersion1 = $isEndpointVersion1;
+
+        return $this;
+    }
+
     public function toArray(): array
     {
-        return [
+        $array = [
             'kvkNummer' => $this->kvkNumber,
             'rsin' => $this->rsin,
             'vestigingsnummer' => $this->vestigingsnummer,
@@ -116,7 +148,25 @@ class SearchQuery implements QueryInterface
             'type' => $this->type,
             'inclusiefinactieveregistraties' => $this->inclusiefinactieveregistraties,
             'pagina' => $this->pagina,
-            'aantal' => $this->aantal,
         ];
+
+        if ($this->isEndpointVersion1) {
+            $array['aantal'] = $this->aantal;
+            $array['handelsnaam'] = $this->handelsnaam;
+            $array['huisnummerToevoeging'] = $this->huisletter;
+        } else {
+            $array['resultatenPerPagina'] = $this->aantal;
+            $array['naam'] = $this->handelsnaam;
+
+            $array['postbusnummer'] = $this->postbusnummer;
+            $array['huisletter'] = $this->huisletter;
+
+            if (is_string($array['type'])) {
+                $array['type'] = str_replace(',', '&', $array['type']);
+            }
+        }
+
+
+        return $array;
     }
 }

--- a/src/Http/SearchQueryInterface.php
+++ b/src/Http/SearchQueryInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Appvise\KvkApi\Http;
+
+interface SearchQueryInterface extends QueryInterface
+{
+    public function setIsEndpointVersion1(bool $isEndpointVersion1): self;
+}

--- a/src/KvkClient.php
+++ b/src/KvkClient.php
@@ -12,6 +12,7 @@ use Appvise\KvkApi\Model\Company\EigenaarFactory;
 use Appvise\KvkApi\Model\Company\VestigingFactory;
 use Appvise\KvkApi\Model\Company\BasisProfielFactory;
 use Appvise\KvkApi\Model\Company\VestigingListFactory;
+use Appvise\KvkApi\Model\ResultaatInterface;
 
 final class KvkClient implements KvkClientInterface
 {
@@ -64,6 +65,14 @@ final class KvkClient implements KvkClientInterface
         $result = $this->decodeJson($response);
 
         return SearchMapper::fromResponse($result);
+    }
+
+    public function searchV2(QueryInterface $query): ResultaatInterface
+    {
+        $response = $this->client->hitEndpoint("{$this->baseUrl}api/v2/zoeken", $query);
+        $result = $this->decodeJson($response);
+
+        return SearchMapper::fromV2Response($result);
     }
 
     public function getBasisProfiel(QueryInterface $query)

--- a/src/KvkClient.php
+++ b/src/KvkClient.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Appvise\KvkApi;
 
+use Appvise\KvkApi\Http\SearchQueryInterface;
 use Appvise\KvkApi\Model\Link;
 use Appvise\KvkApi\Http\QueryInterface;
 use Appvise\KvkApi\Http\ClientInterface;
@@ -67,8 +68,11 @@ final class KvkClient implements KvkClientInterface
         return SearchMapper::fromResponse($result);
     }
 
-    public function searchV2(QueryInterface $query): ResultaatInterface
+    public function searchV2(SearchQueryInterface $query): ResultaatInterface
     {
+        // Forcefully update to V2 so the proper parameters will be used in toArray.
+        $query->setIsEndpointVersion1(false);
+
         $response = $this->client->hitEndpoint("{$this->baseUrl}api/v2/zoeken", $query);
         $result = $this->decodeJson($response);
 

--- a/src/KvkClientInterface.php
+++ b/src/KvkClientInterface.php
@@ -3,6 +3,7 @@
 namespace Appvise\KvkApi;
 
 use Appvise\KvkApi\Http\QueryInterface;
+use Appvise\KvkApi\Http\SearchQueryInterface;
 use Appvise\KvkApi\Model\Link;
 use Appvise\KvkApi\Model\ResultaatInterface;
 
@@ -10,7 +11,7 @@ interface KvkClientInterface
 {
     public function search(QueryInterface $query);
 
-    public function searchV2(QueryInterface $query): ?ResultaatInterface;
+    public function searchV2(SearchQueryInterface $query): ?ResultaatInterface;
 
     public function getBasisProfiel(QueryInterface $query);
 

--- a/src/KvkClientInterface.php
+++ b/src/KvkClientInterface.php
@@ -4,10 +4,13 @@ namespace Appvise\KvkApi;
 
 use Appvise\KvkApi\Http\QueryInterface;
 use Appvise\KvkApi\Model\Link;
+use Appvise\KvkApi\Model\ResultaatInterface;
 
 interface KvkClientInterface
 {
     public function search(QueryInterface $query);
+
+    public function searchV2(QueryInterface $query): ?ResultaatInterface;
 
     public function getBasisProfiel(QueryInterface $query);
 

--- a/tests/Integration/ClientTest.php
+++ b/tests/Integration/ClientTest.php
@@ -49,7 +49,7 @@ class ClientTest extends TestCase
      **/
     public function searchV2(string $kvkNumber)
     {
-        $query = new SearchQuery();
+        $query = new SearchQuery(true);
         $query->setKvkNumber($kvkNumber);
 
         $resultaten = $this->client->searchV2($query);

--- a/tests/Integration/ClientTest.php
+++ b/tests/Integration/ClientTest.php
@@ -45,6 +45,23 @@ class ClientTest extends TestCase
 
     /**
      * @test
+     * @dataProvider getKvkNumbers
+     **/
+    public function searchV2(string $kvkNumber)
+    {
+        $query = new SearchQuery();
+        $query->setKvkNumber($kvkNumber);
+
+        $resultaten = $this->client->searchV2($query);
+
+        foreach ($resultaten->getResultaten() as $searchResult) {
+            $this->assertInstanceOf(ResultaatItem::class, $searchResult);
+            $this->assertEquals($kvkNumber, $searchResult->getKvkNumber());
+        }
+    }
+
+    /**
+     * @test
      * @dataProvider getNonExistingKvkNumbers
      **/
     public function search_non_existing_companies_should_throw_exception(string $kvkNumber)


### PR DESCRIPTION
https://developers.kvk.nl/documentation/migration-zoeken-v2

Vanaf 29 juli 2024 is de oude Zoeken API (V1) niet meer beschikbaar.